### PR TITLE
update manifest for version 5.1.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -106,7 +106,7 @@
     },
     {
       "projectID": 246320,
-      "fileID": 3107121,
+      "fileID": 3079511,
       "required": true
     },
     {
@@ -231,7 +231,7 @@
     },
     {
       "projectID": 412082,
-      "fileID": 3136093,
+      "fileID": 3138522,
       "required": true
     },
     {


### PR DESCRIPTION
 - fixed the Environmental Creepers wrong file reference (pointed it to the Forge version instead of Fabric version

 - updated Supplementaries to new version